### PR TITLE
Add Colors Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This is being developed for the ESP32
 
 To create a lamp, create `src/app/lamps/lampname.py`.
 
+For an example of a simple lamp look at: `src/app/lamps/simple_lamp.py`
+
 Wiring and assembly info will be here later.
 
 ## Loading Data on the ESP32s

--- a/src/app/colors/__init__.py
+++ b/src/app/colors/__init__.py
@@ -1,0 +1,7 @@
+from .rgb import *
+from .rgbw import *
+from .hsv import *
+from .neopixel import *
+from .pixel_list import *
+
+__all__ = ['RGB', 'RGBW', 'HSV', 'RGBList', 'RGBWList', 'NeoPixel', 'ColorOrder']

--- a/src/app/colors/fastmath.py
+++ b/src/app/colors/fastmath.py
@@ -1,0 +1,41 @@
+'''
+Some useful and simple math functions mostly pulled / inspired by lib8tion in FastLED
+'''
+
+def qadd8(i, j):
+    v = i + j
+    return 255 if v > 255 else v
+
+def qsub8(i, j):
+    v = i + j
+    return 0 if v < 0 else v
+
+def scale8(i, scale):
+    return (i * (1 + scale)) >> 8
+
+# Scales down, but makes sure if i is non-zero the output will be non-zero
+def scale8_video(i, scale):
+    if i and scale:
+        j = ((i * scale) >> 8) + 1
+    else:
+        j = (i * scale) >> 8
+
+    return j
+
+def nscale8x3(r, g, b, scale):
+    scale_fixed = scale + 1
+    r = (r * scale_fixed) >> 8
+    g = (g * scale_fixed) >> 8
+    b = (b * scale_fixed) >> 8
+
+    return r, g, b
+
+
+def nscale8x4(r, g, b, q, scale):
+    scale_fixed = scale + 1
+    r = (r * scale_fixed) >> 8
+    g = (g * scale_fixed) >> 8
+    b = (b * scale_fixed) >> 8
+    q = (q * scale_fixed) >> 8
+
+    return r, g, b, q

--- a/src/app/colors/hsv.py
+++ b/src/app/colors/hsv.py
@@ -1,0 +1,77 @@
+'''
+Tools for handle HSV style color representations.
+''' 
+
+_HSV_SECTION_3 = 0x40
+
+class HSV:
+    '''Simple HSV representation, mostly borrowed from FastLED'''
+    HUE_RED = 0,
+    HUE_ORANGE = 32,
+    HUE_YELLOW = 64,
+    HUE_GREEN = 96,
+    HUE_AQUA = 128,
+    HUE_BLUE = 160,
+    HUE_PURPLE = 192,
+    HUE_PINK = 224
+
+    def __init__(self, h=0, s=255, v=255):
+        self.h = h
+        self.s = s
+        self.v = v
+
+    # Shamelessly stolen from FastLED: 
+    # https://github.com/FastLED/FastLED/blob/master/src/hsv2rgb.cpp
+    # Lots of good stuff in that file, but this was the simplest
+    def to_raw_rgb(self):
+        value = self.val
+        saturation = self.sat
+
+        invsat = 255 - saturation
+        brightness_floor = (value * invsat) >> 8
+
+        color_amplitude = value - brightness_floor
+
+        section = int(self.hue / _HSV_SECTION_3)
+        offset = self.hue % _HSV_SECTION_3
+
+        rampup = offset
+        rampdown = (_HSV_SECTION_3 - 1) - offset
+
+        rampup_amp_adj   = (rampup   * color_amplitude) >> 6
+        rampdown_amp_adj = (rampdown * color_amplitude) >> 6
+
+        rampup_adj_with_floor   = rampup_amp_adj   + brightness_floor
+        rampdown_adj_with_floor = rampdown_amp_adj + brightness_floor
+
+        if section != 0:
+            if section == 1:
+                return (brightness_floor, rampdown_adj_with_floor, rampup_adj_with_floor)
+            else:
+                return (rampup_adj_with_floor, brightness_floor, rampdown_adj_with_floor)
+        else:
+            return (rampdown_adj_with_floor, rampup_adj_with_floor, brightness_floor)
+
+    @property
+    def hue(self):
+        return self.h
+
+    @hue.setter
+    def hue(self, value):
+        self.h = value
+
+    @property
+    def sat(self):
+        return self.s
+
+    @sat.setter
+    def sat(self, value):
+        self.s = value
+
+    @property
+    def val(self):
+        return self.v
+
+    @val.setter
+    def val(self, value):
+        self.v = value

--- a/src/app/colors/neopixel.py
+++ b/src/app/colors/neopixel.py
@@ -1,0 +1,42 @@
+'''
+NeoPixel driver based on the NeoPixel driver in MicroPython
+Adds better support for RGB(W) types and for working with the
+color types in this lib
+'''
+
+from machine import bitstream, Pin
+
+class ColorOrder:
+    RGB  = (0, 1, 2)
+    RBG  = (0, 2, 1)
+    GBR  = (1, 2, 0)
+    GRB  = (1, 0, 2)
+    BRG  = (2, 0, 1)
+    BGR  = (2, 1, 0)
+
+    RGBW = (0, 1, 2, 3)
+    RBGW = (0, 2, 1, 3)
+    GBRW = (1, 2, 0, 3)
+    GRBW = (1, 0, 2, 3)
+    BRGW = (2, 0, 1, 3)
+    BGRW = (2, 1, 0, 3)
+
+class NeoPixel:
+    TIMING_800kHz = (400, 850, 800, 450)
+    TIMING_400hKz = (800, 1700, 1600, 900)
+
+    def __init__(self, pin, pixels, color_order=ColorOrder.RGB, timing=TIMING_800kHz):
+        self.pin = Pin(pin)
+        self.pixels = pixels
+        self.color_order = color_order
+        self.timing = self.TIMING_800kHz
+
+        self.buffer = bytearray(len(pixels) * pixels.bit_per_pixel)
+        self.pin.init(self.pin.OUT)
+
+    def __len__(self):
+        return len(self.pixels)
+
+    def write(self):
+        self.pixels.pack(self.buffer, self.color_order)
+        bitstream(self.pin, 0, self.timing, self.buffer)

--- a/src/app/colors/pixel_list.py
+++ b/src/app/colors/pixel_list.py
@@ -1,0 +1,69 @@
+from .rgb import *
+from .rgbw import *
+
+# Abstract base class for Pixel List types, should never be used directly
+class PixelList:
+    def __init__(self):
+        self._size = 0
+        self._pixels = []
+
+    @property
+    def bit_per_pixel(self):
+        return 0
+
+    def pack(self, bytes, order):
+        pass
+
+    def __len__(self):
+        return self._size
+
+    def __getitem__(self, i):
+        return self._pixels[i]
+
+    def __setitem__(self, i, val):
+        self._pixels[i] = val
+
+    @property
+    def size(self):
+        return self._size
+
+    def fill(self, color):
+        for i in range(len(self._pixels)):
+            self._pixels[i] = color
+
+    def fade(self, scale):
+        for pixel in self._pixels:
+            pixel.fade(scale)
+
+class RGBList(PixelList):
+    def __init__(self, size):
+        self._size = size
+        self._pixels = [RGB() for i in range(size)]
+
+    @property
+    def bit_per_pixel(self):
+        return 3
+
+    def pack(self, bytes, order):
+        for i in range(self.size):
+            offset = i * 3
+            bytes[offset + order[0]] = self._pixels[i].r
+            bytes[offset + order[1]] = self._pixels[i].g
+            bytes[offset + order[2]] = self._pixels[i].b
+
+class RGBWList(PixelList):
+    def __init__(self, size):
+        self._size = size
+        self._pixels = [RGBW() for i in range(size)]
+
+    @property
+    def bit_per_pixel(self):
+        return 4
+
+    def pack(self, bytes, order):
+        for i in range(self.size):
+            offset = i * 4
+            bytes[offset + order[0]] = self._pixels[i].r
+            bytes[offset + order[1]] = self._pixels[i].g
+            bytes[offset + order[2]] = self._pixels[i].b
+            bytes[offset + order[3]] = self._pixels[i].w

--- a/src/app/colors/rgb.py
+++ b/src/app/colors/rgb.py
@@ -1,0 +1,120 @@
+from .fastmath import *
+from .hsv import *
+
+class RGB:
+    def __init__(self, r=0, g=0, b=0):
+        self.r = r
+        self.g = g
+        self.b = b
+
+    def __repr__(self) -> str:
+        return f'RGB({self.r}, {self.g}, {self.b})'
+
+    def __len__(self):
+        return 3
+
+    def __getitem__(self, i):
+        if i == 0:
+            return self.r
+        if i == 1:
+            return self.g
+        if i == 2:
+            return self.b
+
+    @classmethod
+    def from_(cls, val):
+        if isinstance(val, RGB):
+            return cls.from_rgb(val)
+        if isinstance(val, HSV):
+            return cls.from_hsv(val)
+        if isinstance(val, tuple):
+            return cls.from_tuple(val)
+        if isinstance(val, int):
+            return cls.from_code(val)
+        if isinstance(val, str):
+            return cls.from_hex_string(val)
+
+    @classmethod
+    def from_code(cls, colorcode):
+        r = (colorcode >> 16) & 0xff
+        g = (colorcode >>  8) & 0xff
+        b = (colorcode      ) & 0xff
+        return cls(r, g, b)
+
+    @classmethod
+    def from_rgb(cls, val):
+        return cls(val.r, val.g, val.b)
+
+    @classmethod
+    def from_hsv(cls, val):
+        return cls(*val.to_raw_rgb())
+
+    @classmethod
+    def from_tuple(cls, val):
+        return cls(val[0], val[1], val[2])
+
+    @classmethod
+    def from_hex_string(cls, val):
+        val = val.lstrip('#')
+        rgb = tuple(int(val[i : i + 2], 16) for i in (0, 2, 4))
+        return cls.from_tuple(rgb)
+
+    def __iadd__(self, rhs):
+        self.r = qadd8(self.r, rhs.r)
+        self.g = qadd8(self.g, rhs.g)
+        self.b = qadd8(self.b, rhs.b)
+        return self
+
+    def __add__(self, rhs):
+        ret = RGB.from_rgb(self)
+        ret += rhs
+        return ret
+
+    def __isub__(self, rhs):
+        self.r = qsub8(self.r, rhs.r)
+        self.g = qsub8(self.g, rhs.g)
+        self.b = qsub8(self.b, rhs.b)
+        return self
+
+    def __sub__(self, rhs):
+        ret = RGB.from_rgb(self)
+        ret -= rhs
+        return ret
+
+    def fade(self, scale):
+        self.r, self.g, self.b = nscale8x3(self.r, self.g, self.b, scale)
+
+    def fade_copy(self, scale):
+        ret = RGB.from_rgb(self)
+        ret.fade(scale)
+        return ret
+
+    # --------- Component Properties ---------
+
+    @property
+    def raw(self):
+        return (self.r, self.g, self.b)
+
+    @property
+    def red(self):
+        return self.r
+
+    @red.setter
+    def red(self, value):
+        self.r = value
+
+    @property
+    def green(self):
+        return self.g
+
+    @green.setter
+    def green(self, value):
+        self.g = value
+
+    @property
+    def blue(self):
+        return self.b
+
+    @blue.setter
+    def blue(self, value):
+        self.b = value

--- a/src/app/colors/rgbw.py
+++ b/src/app/colors/rgbw.py
@@ -1,0 +1,175 @@
+from .fastmath import *
+from .rgb import *
+from .hsv import *
+
+class RGBW:
+    def __init__(self, r=0, g=0, b=0, w=0):
+        self.r = r
+        self.g = g
+        self.b = b
+        self.w = w
+
+    def __repr__(self) -> str:
+        return f'RGBW({self.r}, {self.g}, {self.b}, {self.w})'
+
+    def __len__(self):
+        return 4
+
+    def __getitem__(self, i):
+        if i == 0:
+            return self.r
+        if i == 1:
+            return self.g
+        if i == 2:
+            return self.b
+        if i == 3:
+            return self.w
+
+    @classmethod
+    def from_(cls, val):
+        if isinstance(val, RGB):
+            return cls.from_rgb(val)
+        if isinstance(val, RGBW):
+            return cls.from_rgbw(val)
+        if isinstance(val, HSV):
+            return cls.from_hsv(val)
+        if isinstance(val, tuple):
+            return cls.from_tuple(val)
+        if isinstance(val, int):
+            return cls.from_code(val)
+        if isinstance(val, str):
+            return cls.from_hex_string(val)
+
+    @classmethod
+    def from_code(cls, colorcode):
+        r = (colorcode >> 24) & 0xff
+        g = (colorcode >> 16) & 0xff
+        b = (colorcode >>  8) & 0xff
+        w = (colorcode      ) & 0xff
+        return cls(r, g, b, w)
+
+    @classmethod
+    def from_rgb(cls, val):
+        return cls(val.r, val.g, val.b)
+
+    # Convert RGB to RGBW.  Simply finds the common white in the 
+    # `r`, `g`, `b` components and places that in `white` then
+    # decrements the components.
+    #
+    # Eg. RGB(100, 80, 60) -> RGBW(40, 20, 0, 60)
+    # 
+    # !!! Experimental !!!
+    #  `brightness_boost` my weird attempt at better leveraging RGBW
+    # strips with RGB values.  This will leave a percentage of the 
+    # original component value in while still adding it to white.
+    # `brightness_boost` range: 0 - 255. 255 being full boost, 0 being 
+    # none. The scale is linear.
+    #
+    # Eg. RGB(100, 80, 60) with boost = 127 -> RGBW(80, 60, 20, 60)
+    @classmethod
+    def remap_rgb(cls, val, brightness_boost=0):
+        w = min(val.r, val.g, val.b)
+
+        boost = scale8(w, brightness_boost)
+
+        r = (val.r - w) + boost
+        g = (val.g - w) + boost
+        b = (val.b - w) + boost
+
+        return cls(r, g, b, w)
+
+    @classmethod
+    def from_rgbw(cls, val):
+        return cls(val.r, val.g, val.b, val.w)
+
+    @classmethod
+    def from_hsv(cls, val):
+        return cls(*val.to_raw_rgb())
+
+    @classmethod
+    def remap_hsv(cls, val, brightness_boost=0):
+        return cls.remap_rgb(RGB.from_hsv(val), brightness_boost)
+
+    @classmethod
+    def from_tuple(cls, val):
+        return cls(val[0], val[1], val[2], val[3])
+
+    @classmethod
+    def from_hex_string(cls, val):
+        if len(val) == 7:
+            return cls.from_rgb(RGB.from_hex_string(val))
+
+        val = val.lstrip('#')
+        rgbw = tuple(int(val[i : i + 2], 16) for i in (0, 2, 4, 6))
+        return cls.from_tuple(rgbw)
+
+    def __iadd__(self, rhs):
+        self.r = qadd8(self.r, rhs.r)
+        self.g = qadd8(self.g, rhs.g)
+        self.b = qadd8(self.b, rhs.b)
+        self.w = qadd8(self.w, rhs.w)
+        return self
+
+    def __add__(self, rhs):
+        ret = RGBW.from_rgbw(self)
+        ret += rhs
+        return ret
+
+    def __isub__(self, rhs):
+        self.r = qsub8(self.r, rhs.r)
+        self.g = qsub8(self.g, rhs.g)
+        self.b = qsub8(self.b, rhs.b)
+        self.w = qsub8(self.w, rhs.w)
+        return self
+
+    def __sub__(self, rhs):
+        ret = RGBW.from_rgbw(self)
+        ret -= rhs
+        return ret
+
+    def fade(self, scale):
+        self.r, self.g, self.b, self.w = nscale8x4(self.r, self.g, self.b, self.w, scale)
+        return self
+
+    def fade_copy(self, scale):
+        ret = RGBW.from_rgb(self)
+        ret.fade(scale)
+        return ret
+
+    # --------- Component Properties ---------
+
+    @property
+    def raw(self):
+        return (self.r, self.g, self.b, self.w)
+
+    @property
+    def red(self):
+        return self.r
+
+    @red.setter
+    def red(self, value):
+        self.r = value
+
+    @property
+    def green(self):
+        return self.g
+
+    @green.setter
+    def green(self, value):
+        self.g = value
+
+    @property
+    def blue(self):
+        return self.b
+
+    @blue.setter
+    def blue(self, value):
+        self.b = value
+
+    @property
+    def white(self):
+        return self.w
+
+    @white.setter
+    def white(self, value):
+        self.w = value

--- a/src/app/lamp_core/base_lamp.py
+++ b/src/app/lamp_core/base_lamp.py
@@ -1,5 +1,6 @@
 from ..network.coding import Codes
 from ..network.network import LampNetworkObserver
+from ..colors import *
 
 class BaseLamp(LampNetworkObserver):
     '''
@@ -10,11 +11,11 @@ class BaseLamp(LampNetworkObserver):
     def __init__(self, network, base_color, shade_color):
         self.network = network
 
-        self.base_color = self._hex_to_rgb(base_color)
-        self.shade_color = self._hex_to_rgb(shade_color)
+        self.base_color = RGBW.from_(base_color)
+        self.shade_color = RGBW.from_(shade_color)
 
-        self.network.announce_attribute(Codes.BASE_COLOR, self.base_color)
-        self.network.announce_attribute(Codes.SHADE_COLOR, self.shade_color)
+        self.network.announce_attribute(Codes.BASE_COLOR, self.base_color.raw)
+        self.network.announce_attribute(Codes.SHADE_COLOR, self.shade_color.raw)
 
     async def update(self):
         '''
@@ -23,8 +24,4 @@ class BaseLamp(LampNetworkObserver):
         30+ (ideally 60+) framerate.
         '''
         pass
-
-    def _hex_to_rgb(self, value):
-        value = value.lstrip('#')
-        rgb = tuple(int(value[i:i+2], 16) for i in (0, 2, 4))
-        return (0,0,0,255) if rgb == (255,255,255) else rgb + (0,)
+    

--- a/src/app/lamps/simple_lamp.py
+++ b/src/app/lamps/simple_lamp.py
@@ -1,0 +1,74 @@
+from ..lamp_core.base_lamp import BaseLamp
+from ..network.coding import Codes
+from ..colors import *
+
+class SimpleLamp(BaseLamp):
+    BASE_COLOR = RGBW(0, 255, 0, 0)
+    SHADE_COLOR = RGBW(255, 197, 143, 255)
+
+    SHADE_PIN = 13
+    BASE_PIN = 12
+
+    def __init__(self, network) -> None:
+        super().__init__(network, self.BASE_COLOR, self.SHADE_COLOR)
+
+        # Tell the networking layer to listen for other lamp events
+        network.add_observer(self)
+
+        self.shade_color = self.SHADE_COLOR
+
+        # Create LEDs for the SHADE
+        self.shade_pixels = RGBWList(40)
+        self.shade_driver = NeoPixel(self.SHADE_PIN, self.shade_pixels, ColorOrder.GRBW)
+
+        # Create LEDs for the BASE
+        self.base_pixels = RGBWList(40)
+        self.base_driver = NeoPixel(self.BASE_PIN, self.base_pixels, ColorOrder.GRBW)
+
+        self.color_step = 0
+
+    # Called to update the frame
+    async def update(self):
+        self.shade_pixels.fill(self.shade_color)
+
+        # The base color will hue cycle
+        self.color_step %= 0xff
+        base_color = RGBW.from_hsv(HSV(self.color_step))
+        self.base_pixels.fill(base_color)
+        self.color_step += 3
+
+        # Write the lighting data to the leds
+        self.shade_driver.write()
+        self.base_driver.write()
+
+    # Called any time we spot a new lamp in the wild
+    async def new_lamp_appeared(self, new_lamp):
+        print(f'New Lamp: {new_lamp}')
+
+    # Called everytime anything changes about the lamp, including
+    # rssi. It's a pretty noisey function
+    async def lamp_changed(self, lamp):
+        pass
+
+    # Called everytime a specific attribute changes, so you can
+    # respond to just a BASE_COLOR change or something like that
+    async def lamp_attribute_changed(self, lamp, attribute):
+        print(f"Attribute: {lamp.name} - {attribute.code}")
+
+    # List which lamps no longer are around.
+    async def lamps_departed(self, lamps):
+        print(f'Lamps departed: {lamps}')
+        pass
+
+    # Called when a broadcast message is recieved.
+    async def message_observed(self, message):
+        if message.code == Codes.SHADE_OVERRIDE:
+            print("Switching to SHADE_OVERRIDE color")
+            self.shade_color = RGBW.from_(message.payload)
+
+    # Called when a broadcast message has expired and not longer should
+    # be observed
+    async def message_stopped(self, code):
+        if code == Codes.SHADE_OVERRIDE:
+            print("Stopping SHADE_OVERRIDE color")
+            self.shade_color = self.SHADE_COLOR


### PR DESCRIPTION
This PR adds a python module for managing color information and covering between `RGB`, `RGBW`, and `HSV`.

There is also an altered `neopixel` library here to easily support varible color orderings and allow for easy or rendering the Color types here to leds.

See the `sample_lamp.py` for some better explanation of what's going on here. 

Ideally this file will be converted into c to make it run quickly.  There is a fair bit of inspiration from FastLED here, and everything operates on 8bit color values to avoid use of the FPU.  Build this down to a binary `mpy` for the `Xtensa` chip shouldn't be too hard.  I started barking up the tree to make a Docker container that can cross compile, but ran out of time.

