### PR TITLE
Fixing double inclusion of knockout behaviors

### DIFF
--- a/software/lamp-os/src/components/network/wifi.cpp
+++ b/software/lamp-os/src/components/network/wifi.cpp
@@ -121,7 +121,7 @@ void WifiComponent::begin(Config *inConfig) {
       [](AsyncWebServerRequest *request) {},
       nullptr,
       [&](AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total) {
-        size_t status;
+        size_t status = 0;
         try {
           String buf;
           for (size_t i = 0; i < len; i++) {

--- a/software/lamp-os/src/core/compositor.cpp
+++ b/software/lamp-os/src/core/compositor.cpp
@@ -12,8 +12,9 @@ void Compositor::begin(std::vector<AnimatedBehavior*> inBehaviors, std::vector<F
 
   // Adds some basic behavior layers that are common to all framebuffers
   for (int i = 0; i < frameBuffers.size(); i++) {
-    startupBehaviors.push_back(new FadeInBehavior(frameBuffers[i], STARTUP_ANIMATION_FRAMES));
     behaviors.push_back(new IdleBehavior(frameBuffers[i], 0, true));
+    startupBehaviors.push_back(new IdleBehavior(frameBuffers[i], 0, true));
+    startupBehaviors.push_back(new FadeInBehavior(frameBuffers[i], STARTUP_ANIMATION_FRAMES));
   }
 
   // append all of the non critical behaviors

--- a/software/lamp-os/src/lamps/standard_lamp.cpp
+++ b/software/lamp-os/src/lamps/standard_lamp.cpp
@@ -65,8 +65,7 @@ void initBehaviors(lamp::Config* config) {
                     &shadeConfiguratorBehavior,
                     &baseConfiguratorBehavior,
                     &baseFadeOutBehavior,
-                    &shadeFadeOutBehavior,
-                    &baseKnockoutBehavior},
+                    &shadeFadeOutBehavior},
                    {&shade, &base},
                    config->lamp.homeMode);
 


### PR DESCRIPTION
This change: 
 - moves knockout only to the overlay  
 - fixes a linter check