### PR TITLE
publish firmware via GitHub Releases; add stable + beta channels

### DIFF
--- a/.github/workflows/lamp-os-ci.yml
+++ b/.github/workflows/lamp-os-ci.yml
@@ -3,8 +3,8 @@ name: LampOS CI
 
 on:
   push:
-    branches:
-      - '*'
+    branches-ignore:
+      - beta
   pull_request:
 
 jobs:

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -15,7 +15,6 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           name: distribution
@@ -32,7 +31,6 @@ jobs:
           tag_name: beta
           name: Beta build
           prerelease: true
-          make_latest: 'false'
           body: |
             Rolling beta build from `beta` branch (commit ${{ github.sha }}).
 

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -1,0 +1,45 @@
+name: Release (beta)
+
+on:
+  push:
+    branches:
+      - beta
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: distribution
+      - uses: actions/download-artifact@v4
+        with:
+          name: updates
+          path: updates
+      - name: Replace rolling beta release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release delete beta --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" || true
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: beta
+          name: Beta build
+          prerelease: true
+          make_latest: 'false'
+          body: |
+            Rolling beta build from `beta` branch (commit ${{ github.sha }}).
+
+            Unstable, untested — use at your own risk.
+          files: |
+            distribution.bin
+            updates/bootloader.bin
+            updates/partitions.bin
+            updates/firmware.bin
+            updates/spiffs.bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: distribution
+      - uses: actions/download-artifact@v4
+        with:
+          name: updates
+          path: updates
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            distribution.bin
+            updates/bootloader.bin
+            updates/partitions.bin
+            updates/firmware.bin
+            updates/spiffs.bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
           path: updates
       - uses: softprops/action-gh-release@v2
         with:
+          make_latest: legacy
           files: |
             distribution.bin
             updates/bootloader.bin

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ src/main.py
 .vscode/settings.json
 .vscode/
 node_modules/
+
+# Firmware binary — published via GitHub Releases, not committed
+docs/distribution.bin

--- a/docs/index.html
+++ b/docs/index.html
@@ -110,6 +110,19 @@
           manifest="manifest_format.json"
         ></esp-web-install-button>
       </div>
+      <div style="width: 700px; padding-top: 60px; border-top: 1px solid var(--color-border); margin-top: 60px;">
+        <h3 style="font-weight: 700;">Beta channel</h3>
+        <p style="background: rgba(225, 164, 74, 0.12); border-left: 3px solid var(--color-warning); padding: 12px 16px; margin: 12px 0;">
+          <strong>Warning:</strong> Beta builds are rolling, unstable, and untested.
+          They may contain bugs, break OTA, or fail to boot. Only install if you're
+          comfortable reflashing your lamp over USB to recover.
+        </p>
+        <div style="padding-top: 20px;">
+          <esp-web-install-button
+            manifest="manifest_beta.json"
+          ></esp-web-install-button>
+        </div>
+      </div>
     </div>
   <script
     type="module"

--- a/docs/manifest_beta.json
+++ b/docs/manifest_beta.json
@@ -1,0 +1,14 @@
+{
+  "name": "LampOS (beta)",
+  "version": "0.0.0-beta",
+  "funding_url": "https://esphome.io/guides/supporters.html",
+  "new_install_prompt_erase": true,
+  "builds": [
+    {
+      "chipFamily": "ESP32",
+      "parts": [
+        { "path": "https://github.com/wearelamplit/lamp-os/releases/download/beta/distribution.bin", "offset": 0 }
+      ]
+    }
+  ]
+}

--- a/docs/manifest_format.json
+++ b/docs/manifest_format.json
@@ -7,7 +7,7 @@
     {
       "chipFamily": "ESP32",
       "parts": [
-        { "path": "distribution.bin", "offset": 0 }
+        { "path": "https://github.com/wearelamplit/lamp-os/releases/latest/download/distribution.bin", "offset": 0 }
       ]
     }
   ]


### PR DESCRIPTION
## Summary

- Stop committing `docs/distribution.bin` to git; publish it to GitHub Releases instead. Install page manifest now points at `releases/latest/download/distribution.bin`.
- **Stable channel** (`release.yml`): triggered by pushing a `v*` tag. Builds via the existing reusable `build.yml`, merges binaries with `esptool merge-bin`, and publishes a non-prerelease GitHub Release with `make_latest: legacy` so backport hotfixes don't accidentally downgrade install-page users.
- **Beta channel** (`release-beta.yml`): triggered by pushing to the `beta` branch. Replaces the rolling `beta` release+tag on each run, marked `prerelease: true` so it can't grab the "Latest" badge. Manifest is `manifest_beta.json` pointing at `releases/download/beta/distribution.bin`.
- Install page (`docs/index.html`) gets a second `esp-web-install-button` under a stability warning.
- `lamp-os-ci.yml` skipped on `beta` to avoid double-builds (the release workflow already invokes `build.yml`).

## Files

- `.github/workflows/release.yml` (new) — stable channel
- `.github/workflows/release-beta.yml` (new) — beta channel
- `.github/workflows/lamp-os-ci.yml` — `branches-ignore: [beta]`
- `docs/manifest_format.json` — absolute URL to release asset
- `docs/manifest_beta.json` (new) — beta manifest
- `docs/index.html` — second install button + warning
- `docs/distribution.bin` — removed from git
- `.gitignore` — keeps it untracked

## Post-merge step

The `beta` branch was created from `main` *before* this PR, so it doesn't yet contain `release-beta.yml`. After this merges, fast-forward beta once to pick up the workflow file:

\`\`\`
git fetch origin
git push origin main:beta
\`\`\`

After that, pushes to \`beta\` will trigger rolling prereleases.

## Test plan

- [ ] After merge: tag a no-op commit (e.g. \`v0.0.0-test\`), confirm \`release.yml\` runs, release publishes with all 5 binaries, "Latest" badge is set.
- [ ] After post-merge fast-forward: push a no-op commit to \`beta\`, confirm \`release-beta.yml\` runs, rolling \`beta\` release publishes with \`prerelease: true\`, "Latest" badge unchanged.
- [ ] Open the install page from GitHub Pages, verify both install buttons load their manifests and the binaries fetch (CORS) — try stable first, then beta.
- [ ] Tag a backport like \`v0.0.1\` after a higher \`v0.1.0\` exists; confirm \`make_latest: legacy\` keeps the higher version as "Latest".

🤖 Generated with [Claude Code](https://claude.com/claude-code)