### PR TITLE
restore captive portal with selective canHandle

### DIFF
--- a/software/lamp-os/src/components/network/wifi.cpp
+++ b/software/lamp-os/src/components/network/wifi.cpp
@@ -4,6 +4,7 @@
 #include <ArduinoJson.h>
 #include <AsyncJson.h>
 #include <AsyncTCP.h>
+#include <DNSServer.h>
 #include <ESPAsyncWebServer.h>
 #include <ESPmDNS.h>
 #include <ElegantOTA.h>
@@ -22,6 +23,7 @@ static AsyncWebServer server(80);
 static AsyncWebSocketMessageHandler wsHandler;
 static AsyncWebSocket ws("/ws", wsHandler.eventHandler());
 static AsyncCorsMiddleware cors;
+static DNSServer dnsServer;
 Preferences prefs;
 
 #ifdef LAMP_DEBUG
@@ -47,14 +49,24 @@ void onWiFiEvent(WiFiEvent_t event) {
 #endif
 };
 
+// Intercepts only the well-known captive-portal-detection URLs each OS pings to
+// decide whether the WiFi has internet. Responding with a redirect triggers the
+// "Sign in to network" notification on Android and the equivalent popup on iOS.
 class CaptiveRequestHandler : public AsyncWebHandler {
  public:
-  bool canHandle(__unused AsyncWebServerRequest *request) const override {
-    return true;
+  bool canHandle(AsyncWebServerRequest *request) const override {
+    const String &u = request->url();
+    return u == "/generate_204"             // Android
+        || u == "/gen_204"                  // Android (older)
+        || u == "/hotspot-detect.html"      // iOS / macOS
+        || u == "/library/test/success.html"  // iOS
+        || u == "/connecttest.txt"          // Windows
+        || u == "/ncsi.txt"                 // Windows
+        || u == "/redirect";                // Windows
   };
 
   void handleRequest(AsyncWebServerRequest *request) {
-    request->send(SPIFFS, "/index.html.gz", String(), false);
+    request->redirect("http://192.168.4.1/");
   };
 };
 
@@ -161,12 +173,16 @@ void WifiComponent::begin(Config *inConfig) {
   });
   server.addMiddleware(&cors);
   server.addHandler(&ws);
+  server.addHandler(new CaptiveRequestHandler()).setFilter(ON_AP_FILTER);
   server.begin();
+  dnsServer.start(53, "*", WiFi.softAPIP());
   artnet.begin();
 };
 
 void WifiComponent::tick() {
   uint32_t now = millis();
+
+  dnsServer.processNextRequest();
 
   if (now > lastWebSocketCleanTimeMs + WEBSOCKET_CLEAN_TIME_MS &&
       now > lastWebSocketUpdateTimeMs + WEBSOCKET_CLEAN_TIME_MS) {


### PR DESCRIPTION
## Summary
- On beta, `CaptiveRequestHandler` is declared in `wifi.cpp` but never registered with the web server, and no `DNSServer` runs — so phones connecting to the lamp's SoftAP never see the "Sign in to network" prompt.
- Cherry-picks 51838c0 from `topic/captive-portal` (just the captive-portal commit; leaves the other 4 unrelated commits on that branch alone).
- Re-registers the handler with `ON_AP_FILTER` and a narrowed `canHandle()` that only matches OS captive-detection URLs (Android `/generate_204`, iOS `/hotspot-detect.html`, Windows `/ncsi.txt`, etc.), so `/ws`, `/update`, `/settings` pass through untouched.
- Starts a `DNSServer` on port 53 that hijacks all lookups to the SoftAP IP — needed for the Android-with-LTE case where `lamp.local` won't resolve.

## Test plan
- [ ] Flash beta + this commit to a lamp.
- [ ] Connect Android phone (LTE on) to the lamp AP → "Sign in to network" banner appears.
- [ ] Connect iOS phone to the lamp AP → captive popup opens.
- [ ] Verify `/ws`, `/settings`, `/update` still respond on the AP without being redirected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)